### PR TITLE
Use actions instead of gh-pages branch

### DIFF
--- a/.github/workflows/build-deploy-book.yml
+++ b/.github/workflows/build-deploy-book.yml
@@ -1,4 +1,4 @@
-name: IGA-Python Jupyter Book
+name: Jupyter book
 
 on:
   push:
@@ -17,7 +17,7 @@ jobs:
             python-version: '3.12'
           - os: macos-15
             python-version: '3.12'
-    name: build_${{ matrix.os }}_python${{ matrix.python-version }}
+    name: build / ${{ matrix.os }} / python${{ matrix.python-version }}
     env:
       FC: gfortran-14
 

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -79,7 +79,7 @@ jobs:
       uses: actions/upload-pages-artifact@v3
       with:
         path: _build/html
-        name: github-pages_${{ matrix.os }}$_python${{ matrix.python-version }}$
+        name: github-pages_${{ matrix.os }}_python${{ matrix.python-version }}
       
   deploy:
     if: github.event_name != 'pull_request'
@@ -93,4 +93,4 @@ jobs:
       id: deployment
       uses: actions/deploy-pages@v4
       with:
-        artifact_name: github-pages_ubuntu-24.04_python3.12$
+        artifact_name: github-pages_ubuntu-24.04_python3.12

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -78,9 +78,12 @@ jobs:
       run: make docs
 
     - name: Setup Pages
+      if: matrix.os == 'ubuntu-24.04'
       uses: actions/configure-pages@v5
 
     - name: Upload artifact
+      if: matrix.os == 'ubuntu-24.04'
+      id: deployment
       uses: actions/upload-pages-artifact@v3
       with:
         path: '_build/html'

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -83,7 +83,7 @@ jobs:
 
   deploy:
     if: github.event_name != 'pull_request'
-    needs: build_book
+    needs: build
     runs-on: ubuntu-24.04
     environment:
       name: github-pages

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -17,7 +17,7 @@ jobs:
             python-version: '3.12'
           - os: macos-15
             python-version: '3.12'
-    name: build [${{ matrix.os }} / Python ${{ matrix.python-version }}]
+    name: build_${{ matrix.os }}_python${{ matrix.python-version }}
     env:
       FC: gfortran-14
 
@@ -75,12 +75,12 @@ jobs:
       run: make docs
 
     - name: Upload artifact
-      if: matrix.os == 'ubuntu-24.04'
       id: deployment
       uses: actions/upload-pages-artifact@v3
       with:
-        path: '_build/html'
-
+        path: _build/html
+        name: github-pages_${{ matrix.os }}$_python${{ matrix.python-version }}$
+      
   deploy:
     if: github.event_name != 'pull_request'
     needs: build
@@ -92,3 +92,5 @@ jobs:
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v4
+      with:
+        artifact_name: github-pages_ubuntu-24.04_python3.12$

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  deploy-book:
+  build_book:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -77,11 +77,22 @@ jobs:
     - name: Build Jupyter Book
       run: make docs
 
-    - name: Deploy to GitHub Pages
-      if: ${{ (github.ref == 'refs/heads/master') && startsWith(matrix.os, 'ubuntu') }}
-      run: |
-        pip install ghp-import
-        ghp-import -n -p -f _build/html
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
 
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: '_build/html'
+
+  deploy_book:
+    if: github.event_name != 'pull_request'
+    needs: build_book
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -1,4 +1,4 @@
-name: Build IGA-Python Jupyter Book
+name: IGA-Python Jupyter Book
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build_book:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -15,14 +15,11 @@ jobs:
         include:
           - os: ubuntu-24.04
             python-version: '3.12'
-
           - os: macos-15
             python-version: '3.12'
-
+    name: build [${{ matrix.os }} / Python ${{ matrix.python-version }}]
     env:
       FC: gfortran-14
-
-    name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v4
@@ -88,7 +85,7 @@ jobs:
       with:
         path: '_build/html'
 
-  deploy_book:
+  deploy:
     if: github.event_name != 'pull_request'
     needs: build_book
     runs-on: ubuntu-24.04

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -74,10 +74,6 @@ jobs:
     - name: Build Jupyter Book
       run: make docs
 
-    - name: Setup Pages
-      if: matrix.os == 'ubuntu-24.04'
-      uses: actions/configure-pages@v5
-
     - name: Upload artifact
       if: matrix.os == 'ubuntu-24.04'
       id: deployment

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
 Ahmed Ratnani
 Mohamed Jalal Maaouni
 Paul Rigor
-
+Yaman Güçlü

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to IGA-Python
 
-This project provides a tutorial for isogeometric analysis (IGA) using Python and the Psydac library (pyccel/psydac). The numerical examples can be consulted online at pyccel.github.io/IGA-Python, or run with JupyterNotebook on a personal computer.
+This project provides a tutorial for isogeometric analysis (IGA) using Python and the Psydac library (pyccel/psydac). The numerical examples can be consulted online at [pyccel.github.io/IGA-Python](https://pyccel.github.io/IGA-Python), or run with Jupyter Notebook on a personal computer.
 
 ## Editing and building IGA-Python locally
 
@@ -70,3 +70,15 @@ nb-clean remove-filter
 3. Stage the modified files with `git add`. Then run `git diff` to check if the changed `*.ipynb` notebooks doesn't include unnecessary diffs (e.g. notebook metadata).
 4. `git commit` your changes.
 5. *OPTIONAL*. Share your changes to this repo via a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
+
+## Contributing
+
+There are several ways to contribute to this project.
+If you find a problem, please check if this is already discussed in one of [our issues](https://github.com/pyccel/IGA-Python/issues) and feel free to add your opinion; if not, please create a [new issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-an-issue).
+If you want to fix an issue, improve our notebooks, or add a new example, please [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) our Git repository, make and commit your changes, and create a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) (PRs).
+
+All PRs are reviewed by the project maintainers.
+During the PR review, GitHub workflows are triggered on various platforms.
+These workflows build the notebooks and prepare them to be deployed as a static HTML website to [pyccel.github.io/IGA-Python](https://pyccel.github.io/IGA-Python).
+Deploy does not happen before the final merge of the PR, but the HTML files can be downloaded as a zip file from GitHub, and opened with any browser for inspection.
+To download the zip file, select the workflow run of interest from the `Actions` tab, click on `Summary`, and look under `Artifacts`.


### PR DESCRIPTION
Split the workflow into two sequential jobs (`build` and `deploy`), which use dedicated GitHub Actions:
  - The `build` job matrix builds our HTML documentation for GitHub Pages, then it uploads artifacts with job-dependent names using `upload-pages-artifact`. Hence the generated books can be checked during a PR review. This fixes #12.
  - The `deploy` job runs on a single platform after the PR is merged. It deploys the correct artifact to GitHub Pages using `deploy-pages`.

NOTE: We do not need a dedicated branch `gh-pages` any longer.

Other changes:
  - Rename `build-book.yml` to `build-deploy-book.yml`
  - Rename workflow and build jobs
  - Add `Contributing` section to `README.md`, which mentions issues, forks, pull requests, workflows, and artifacts.
  - Add myself to `AUTHORS`.

