### PR TITLE
Ensure GITHUB_TOKEN has write permissions

### DIFF
--- a/.github/workflows/build-deploy-book.yml
+++ b/.github/workflows/build-deploy-book.yml
@@ -88,6 +88,12 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+
+     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
     steps:
     - name: Deploy to GitHub Pages
       id: deployment


### PR DESCRIPTION
After PR #13 the deploy step of our workflows did not have the necessary permissions to upload our website to GitHub Pages. This should fix it.