### PR TITLE
Do not create gfortran symlink on macOS

### DIFF
--- a/.github/workflows/build-deploy-book.yml
+++ b/.github/workflows/build-deploy-book.yml
@@ -18,8 +18,6 @@ jobs:
           - os: macos-15
             python-version: '3.12'
     name: build / ${{ matrix.os }} / python${{ matrix.python-version }}
-    env:
-      FC: gfortran-14
 
     steps:
     - uses: actions/checkout@v4
@@ -54,17 +52,10 @@ jobs:
       run: |
         brew install open-mpi hdf5-mpi libomp
 
-    - name: Check gfortran version
+    - name: Check gfortran version, and location of executable
       run: |
-        if [[ "${{ matrix.os }}" == *"macos"* ]]; then 
-          # pyccel searches for a Fortran compiler exactly named 'gfortran'
-          # which the macos runner doesn't have. A simple workaround is to 
-          # create a symlink named 'gfortran'.
-          FC_path=$(which $FC)
-          FC_dir=$(dirname ${FC_path})
-          ln -sv ${FC_path} ${FC_dir}/gfortran
-        fi
         gfortran --version
+        which gfortran
 
     - name: Install Jupyter Book and Psydac
       run: |
@@ -121,7 +112,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
       pages: write      # to deploy to Pages
       id-token: write   # to verify the deployment originates from an appropriate source


### PR DESCRIPTION
The original CI workflow assumed that an executable `gfortran-14` was available on macOS, but not a `gfortran`. Therefore a symlink named `gfortran` was created without even checking if this was really necessary. Recent CI failures showed instead that a binary file named `gfortran` already existed.

Therefore, we now use the available command `gfortran` on macOS as well as Ubuntu, with no distinction. Fixes #22.